### PR TITLE
Update unix_install_example.sh

### DIFF
--- a/scripts/install/unix_install_example.sh
+++ b/scripts/install/unix_install_example.sh
@@ -14,7 +14,7 @@ BASE_DIR=$(dirname "$SCRIPT")
 # Build raja
 git clone --recursive https://github.com/llnl/raja.git
 cd raja
-git checkout tags/v0.13.0
+git checkout tags/v0.11.0
 # Instantiate all the submodules
 git submodule init
 git submodule update
@@ -128,7 +128,8 @@ cmake ../ -DENABLE_MPI=ON -DENABLE_FORTRAN=ON \
   -DMFEM_DIR=${BASE_DIR}/mfem/install_dir/lib/cmake/mfem/ \
   -DECMECH_DIR=${BASE_DIR}/exacmech/install_dir/ \
   -DRAJA_DIR=${BASE_DIR}/raja/install_dir/share/raja/cmake/ \
-  -DSNLS_DIR=${BASE_DIR}/exacmech/snls/ \
+  -DSNLS_DIR=${BASE_DIR}/exacmech/install_dir/ \
+  -DENABLE_SNLS_V03=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DENABLE_TESTS=ON
 # Sometimes the cmake systems can be a bit difficult and not properly find the MFEM installed location


### PR DESCRIPTION
Hi,

I was trying to install ExaConstit to my new computer and I had to make some small changes to the script to work. I had to use raja v0.11.0 since the ExaCMech couldn't identify the raja cmake files. In the later raja versions cmake files are not located in "${BASE_DIR}/raja/install_dir/share/raja/cmake/". Even if I change the location to "${BASE_DIR}/raja/install_dir/lib/cmake/raja/" I couldn't "make install" without errors. 

Sincerely,
Leonidas 