### PR TITLE
Lattice Strain Postprocessing Scripts

### DIFF
--- a/scripts/postprocessing/adios2_extraction.py
+++ b/scripts/postprocessing/adios2_extraction.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+@author: rjk5987, dcp5303
+
+Developed using ExaConstit/scripts/postprocessing/adios2_example.py
+
+This script extracts specified variables from ExaConstit ADIOS2 binary-pack (.bp) files
+and saves them off in ASCII text format (.txt) for use in other scripts.
+
+Output files prefixed by 'raw_' and labeled by variable name and cycle.
+
+Recommended to configure script in an interactive shell to explore variables,
+then run from the command line.
+
+Heavily compartmentalized to handle large meshes (tested on up to 8M elements),
+so may not be the most efficient method for processing smaller meshes.
+
+User inputs marked with #!!!
+"""
+
+import adios2
+import numpy as np
+import os
+
+# makes console print-outs nicer, can CTRL+F and remove these to eliminate this dependency
+from sty import bg , ef , fg
+
+#%% Global variables related to inputs/outputs. (USER INPUTS HERE)
+
+# int - number of resource sets used for the simulation
+# IMPORTANT: need to set this variable correctly to process all elements in the simulation
+nranks = 48 #!!!
+# bool - whether to overwrite existing outputs from this script
+# (can also take in a list of bools corresponding to each variable)
+overwrite = True #!!!
+# bool - whether to resume from last step saved off if extraction was killed
+# (can also take in a list of bools corresponding to each variable)
+resume = False #!!!
+# bool - whether to use an alternate unpacking procedure that is slower but more memory-efficient (may be necessary for handling larger variables)
+# (can also take in a list of bools corresponding to each variable)
+unpack_alt = [False , False , False , True , False , False] #!!!
+
+#%% Specify filepaths. (USER INPUTS HERE)
+
+# save directory for script outputs, recursively create directory if it doesn't exist
+out_dir = 'dir/to/store/outputs' #!!!
+if not os.path.exists(out_dir) :
+    print(fg.magenta + 'Output directory not found, creating.' + fg.rs)
+    os.makedirs(out_dir)
+else :
+    print(fg.green + 'Output directory found, proceeding.' + fg.rs)
+
+# list of variables to save off (can view available variables in init_vars in next block below)
+# different variables are stored in different ways - not all variables are supported by this script
+# this script should work for any variables that are saved off for every element - some examples of working variables are given below
+vars_out = [
+    'DpEff' ,
+    'ElementVolume' ,
+    'LatticeOrientation' ,
+    'ShearRate' ,
+    'Stress' ,
+    'XtalElasticStrain'
+    ] #!!!
+
+#%% Open ADIOS2 file and explore variables. (USER INPUTS HERE)
+
+# open ADIOS2 binary-pack (.bp) file
+fh = adios2.open('dir/to/exaconstit.bp' , 'r' , engine_type = 'BP4') #!!!
+# list of variables stored in adios2 file
+init_vars = fh.available_variables()
+# total number of cycles saved off (+ initial step at time = 0)
+# if stride > 1 in options.toml, this number will be (# of ExaConstit steps / stride) + 1
+steps = fh.steps()
+
+#%% Extract connectivity information - needed for other variables. (NO INPUTS HERE)
+
+con1d = list()
+index = np.zeros((nranks,2) , dtype = np.int32)
+iend = 0
+
+# Get the initial end node vertices and connectivity array for everything.
+# ADIOS2 doesn't save higher order values, so only have the end nodes.
+# Many repeat vertices, since these are saved off for each element.
+for i in range(nranks) :
+    
+    if (i == 0) :
+        
+        # Pull out connectivity information.
+        con = fh.read('connectivity' , block_id = i)
+        
+        # # Can uncomment to also pull out vertices.
+        # vert = fh.read('vertices' , block_id = i)
+        
+        # # Can uncomment to also pull out grain IDs ('ElementAttribute').
+        # grain = fh.read('ElementAttribute' , block_id = i)
+        # grain = grain[con[:,1]]
+        
+        con1d.append(con[:,1])
+        con = con[:,1::]
+        
+    else :
+        
+        # Pull out connectivity information.
+        tmp = fh.read('connectivity' , block_id = i)
+        con1d.append(tmp[:,1])
+
+        # Connectivity is local to resource set rather than global, so increment to global.
+        tmp = tmp + np.max(con)
+        con = np.vstack((con , tmp[:,1::]))
+        
+        # # Can uncomment to also pull out vertices.
+        # tmp = fh.read('vertices' , block_id = i)
+        # vert = np.vstack((vert , tmp))
+        
+        # # Can uncomment to also pull out grain IDs ('ElementAttribute').
+        # tmp = fh.read('ElementAttribute' , block_id = i)
+        # grain = np.hstack((grain , tmp[con1d[i]]))
+        
+        del tmp
+
+    # indexing variable that will be used later on
+    index[i,0] = iend
+    iend = con.shape[0]
+    index[i,1] = iend
+
+# # Can uncomment to convert grain IDs to int32.
+# grain = np.int32(grain)
+
+conshape = con.shape
+del con
+
+#%% Pull variables directly from adios2 files. (NO INPUTS HERE)
+
+print(ef.bold + bg.green + '\nExtracting raw data.' + bg.rs + ef.rs)
+
+for var in vars_out :
+    
+    print(ef.bold + bg.da_blue + '\nCurrent var: %s' %var + bg.rs + ef.rs)
+    
+    start = 0
+    proceed = True
+    
+    # case handling for whether global bools are lists
+    try :
+        var_overwrite = overwrite[vars_out.index(var)]
+    except :
+        var_overwrite = overwrite
+    
+    try :
+        var_resume = resume[vars_out.index(var)]
+    except :
+        var_resume = resume
+    
+    try :
+        var_unpack_alt = unpack_alt[vars_out.index(var)]
+    except :
+        var_unpack_alt = unpack_alt
+    
+    # case handling for overwrite and resume bools
+    if any(fname.startswith('raw_%s' %var) for fname in os.listdir(out_dir)) :
+        if var_overwrite :
+            if var_resume :
+                for fname in os.listdir(out_dir) :
+                    if fname.startswith('raw_%s' %var) :
+                        start += 1
+                start -= 1
+                print(fg.red + 'File conflicts found for %s in output directory. overwrite = True and resume = True, starting from cycle %0.02d.' %(var , start) + fg.rs)
+            else :
+                print(fg.red + 'File conflicts found for %s in output directory. overwrite = True and resume = False, starting fresh.' %var + fg.rs)
+        else :
+            if var_resume :
+                for fname in os.listdir(out_dir) :
+                    if fname.startswith('raw_%s' %var) :
+                        start += 1
+                print(fg.magenta + 'File conflicts found for %s in output directory. overwrite = False and resume = True, starting from cycle %0.02d.' %(var , start) + fg.rs)
+            else :
+                print(fg.magenta + 'File conflicts found for %s in output directory. overwrite = False and resume = False, skipping variable.' %var + fg.rs)
+                proceed = False
+    else :
+        print(fg.green + 'No conflicting files found for %s in output directory, proceeding.' %var + fg.rs)       
+    
+    # case handling for unpack_alt bool (whether to use alternate unpacking scheme)
+    if proceed and not var_unpack_alt :
+        
+        # accounts for some variables starting at cycle 0 and others at cycle 1
+        dif = steps - int(init_vars[var]['AvailableStepsCount'])
+        if dif == 1 :
+            offset = 1
+        else :
+            offset = 0
+        del dif
+        
+        # initialize
+        top = fh.read(var , block_id = 0)
+        try :
+            var_len = top.shape[1]
+            var_raw = np.empty((var_len , conshape[0] , steps-offset) , order = 'F')
+        except :
+            var_len = 1
+            var_raw = np.empty((conshape[0] , steps-offset) , order = 'F')
+        del top
+        
+        # read
+        print(fg.li_blue + '\nReading %s.' %var + fg.rs)
+        for ii in range(nranks) :
+            print('Loading resource set ' + str(ii+1) + ' of ' + str(nranks) + '.' , end = '\r')           
+            isize = con1d[ii].shape[0] * conshape[1]
+            if var_len > 1 :
+                arr = fh.read(var , start = [0 , 0] , count = [isize , var_len] , step_start = 0 , step_count = steps-offset , block_id = ii)
+                var_raw[: , index[ii , 0]:index[ii , 1] , :] = np.swapaxes(arr[:, con1d[ii] , :], 0 , 2)
+            else :
+                arr = fh.read(var , start = [0] , count = [isize] , step_start = 0 , step_count = steps-offset , block_id = ii).T
+                var_raw[index[ii , 0]:index[ii , 1] , :] = arr[con1d[ii] , :]                
+            del isize , arr
+        print('\nDone reading %s.' %var)
+        
+        # save
+        print(fg.li_blue + '\nSaving %s.' %var + fg.rs)
+        if var_len > 1 :
+            for jj in range(start , steps-offset) :
+                print('Saving step ' + str(jj+1) + ' of ' + str(steps-offset) + '.' , end = '\r')
+                np.savetxt(out_dir + 'raw_%s_%0.02d.txt' %(var , jj+offset) , var_raw[:,:,jj].T)
+        else :
+            for jj in range(start , steps-offset) :
+                print('Saving step ' + str(jj+1) + ' of ' + str(steps-offset) + '.' , end = '\r')
+                np.savetxt(out_dir + 'raw_%s_%0.02d.txt' %(var , jj+offset) , var_raw[:,jj].T)
+        print('\nDone saving %s.' %var)
+        del offset , var_len , var_raw
+        
+    elif proceed and var_unpack_alt :
+        
+        # accounts for some variables starting at cycle 0 and others at cycle 1
+        dif = steps - int(init_vars[var]['AvailableStepsCount'])
+        if dif == 1 :
+            offset = 1
+        else :
+            offset = 0
+        del dif
+        
+        # initialize
+        top = fh.read(var , block_id = 0)
+        try :
+            var_len = top.shape[1]
+            var_raw = np.empty((var_len , conshape[0] , 1) , order = 'F')
+        except :
+            var_len = 1
+            var_raw = np.empty((conshape[0] , 1) , order = 'F')
+        del top
+        
+        step = start
+        
+        # read and save
+        while step < (steps-offset) :
+            print('Processing step ' + str(step+1) + ' of ' + str(steps-offset) + '.' , end = '\r')
+            for ii in range(nranks) :
+                isize = con1d[ii].shape[0] * conshape[1]
+                if var_len > 1 :
+                    arr = fh.read(var , start = [0 , 0] , count = [isize , var_len] , step_start = step , step_count = 1 , block_id = ii)
+                    var_raw[: , index[ii , 0]:index[ii , 1] , :] = np.swapaxes(arr[: , con1d[ii] , :] , 0 , 2)
+                else :
+                    arr = fh.read(var , start = [0] , count = [isize] , step_start = step , step_count = 1 , block_id = ii).T
+                    var_raw[index[ii , 0]:index[ii , 1] , :] = arr[con1d[ii] , :]                
+                del isize , arr
+            if var_len > 1 :
+                np.savetxt(out_dir + 'raw_%s_%0.02d.txt' %(var , step+offset) , var_raw[:,:,0].T)
+            else :
+                np.savetxt(out_dir + 'raw_%s_%0.02d.txt' %(var , step+offset) , var_raw[:,0].T)
+            step += 1
+        print('\nDone saving %s.' %var)
+        del offset , var_len , var_raw , step
+        
+    del start , proceed
+    
+#%% Always close the file when you're finished loading data from it.
+
+fh.close()

--- a/scripts/postprocessing/calc_lattice_strain.py
+++ b/scripts/postprocessing/calc_lattice_strain.py
@@ -62,7 +62,7 @@ def make_matl(mat_name , sgnum , lparms , hkl_ssq_max = 50 , dmin_angstroms = 0.
     Parameters
     ----------
     mat_name : str
-        label for material.
+        user-defined label for material.
     sgnum : int
         space group number for material.
     lparms : list of floats
@@ -86,7 +86,7 @@ def make_matl(mat_name , sgnum , lparms , hkl_ssq_max = 50 , dmin_angstroms = 0.
     return matl
 
 # here is a simple example for IN625 - see function above for what the arguments are
-matl = make_matl(mat_name = 'FCC' , sgnum = 225 , lparms = [3.60 ,]) #!!!
+matl = make_matl(mat_name = 'IN625' , sgnum = 225 , lparms = [3.60 ,]) #!!!
 pd = matl.planeData
 
 #%% Booleans.

--- a/scripts/postprocessing/calc_lattice_strain.py
+++ b/scripts/postprocessing/calc_lattice_strain.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+@author: rjk5987 , dcp5303
+
+This script calculates 'lattice strains', elastic strains along a specified sample direction
+averaged over subsets of elements (grains) belonging to different crystallographic fibers.
+
+Designed to take in 'raw_LatticeOrientation' outputs from adios2_extraction.py
+and 'SampleElasticStrain' outputs from strain_Xtal_to_Sample.py
+
+As-is, also requires that 'ElementVolume' was output from adios2_extraction.py
+for use in a volume-weighted average. Typically does not make a significant difference,
+so the user may wih to remove this below.
+
+Saves lattice strains in ASCII text format (.txt) for use in other scripts.
+Output file named 'lattice_strains' and arranged as step # by lattice plane.
+
+Recommended to configure script in an interactive shell, then run from the command line.
+
+User inputs marked with #!!!
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+import os
+
+# Need a materials.h5 file from HEXRD!!!
+from hexrd import rotations as rot
+from hexrd import material , valunits
+
+# makes console print-outs nicer, can CTRL+F and remove these to eliminate this dependency
+from sty import bg , ef , fg
+
+def load_pdata(filename , d_min , energy , mat): 
+
+    kev  = valunits.valWUnit('beam_energy' , 'energy' , energy , 'keV')
+    dmin = valunits.valWUnit('dmin' , 'length' , d_min , 'angstrom')
+    mats = material.load_materials_hdf5(filename , dmin = dmin , kev = kev)
+    pd   = mats[mat].planeData
+
+    return pd
+
+# conversions between radians and degrees
+d2r = np.pi / 180.
+r2d = 180. / np.pi
+
+#%% Booleans.
+
+# whether to plot the resulting lattice strains vs. cycle when finished
+plot = True #!!!
+# whether to save plot (will save to the same directory as the lattice strain file)
+save_plot = False #!!!
+
+#%% Establish filepaths and directories.
+
+# requires a materials.h5 file created in HEXRD
+mat_file = '/dir/to/materials.h5' #!!!
+# material of interest in material file
+mat = 'IN625' #!!!
+# load peak data for specified material from material file
+# other arguments are minimum d-spacing filter (in angstroms) and beam energy (in keV)
+pd = load_pdata(mat_file , 0.5 , 61.332 , mat) #!!!
+
+# directory where 'raw_LatticeOrientation' files were saved off from adios2_extraction.py
+raw_dir = 'dir/to/adios2_extraction_files/' #!!!
+# directory where 'SampleElasticStrain' files were saved off from strain_Xtal_to_Sample.py
+strain_dir = 'dir/to/strain_Xtal_to_Sample_files/' #!!!
+# save directory for script outputs, recursively create directory if it doesn't exist
+out_dir = 'dir/to/store/outputs/' #!!!
+if not os.path.exists(out_dir) :
+    print(fg.magenta + 'Output directory not found, creating.' + fg.rs)
+    os.makedirs(out_dir)
+else :
+    print(fg.green + 'Output directory found, proceeding.' + fg.rs)
+
+#%% Specify information relevant to simulations and lattice strain calculations.
+
+# count number of simulation steps saved off
+steps = 0
+for fname in os.listdir(raw_dir) :
+    if fname.startswith('raw_LatticeOrientation') :
+        steps += 1
+
+# distance bound - maximum angular distance from crystallographic fiber in degrees (may prefer smaller tolerances for larger meshes)
+distance_bnd = 5
+
+# array of Miller indices for lattice planes/strains of interest (gets transposed to be HEXRD-amenable)
+hkl = np.array([
+    [1,1,1],
+    [2,0,0],
+    [2,2,0],
+    [3,1,1]
+    ]).T
+
+# strain direction of interest in ExaConstit z-up coordinate system (example below for z-axis)
+s_dir = np.array([0,0,1])
+
+#%% Calculate lattice strains.
+
+# initialize array of lattice strains
+lattice_strains = np.zeros((steps , hkl.shape[1]))
+
+print(ef.bold + bg.green + '\nCalculating lattice strains.' + bg.rs + ef.rs)
+
+# iterate over cycles
+for ii in range(steps) :
+    
+    print(ef.bold + bg.da_blue + '\nProcessing step ' + str(ii+1) + ' of ' + str(steps) + '.' + bg.rs + ef.rs)
+    
+    print(fg.li_blue + '\nLoading data.' + fg.rs)
+    vols = np.loadtxt(raw_dir + 'raw_ElementVolume_%0.02d.txt' %ii)
+    quats = np.loadtxt(raw_dir + 'raw_LatticeOrientation_%0.02d.txt' %ii).T
+    strain = np.loadtxt(strain_dir + 'SampleElasticStrain_%0.02d.txt' %ii)
+    print('Data loaded.')
+    
+    print(fg.li_blue + '\nCalculating lattice strains.' + fg.rs)
+    # iterate over lattice planes
+    for jj in range(hkl.shape[1]) :
+        
+        print('Processing hkl ' + str(jj+1) + ' of ' + str(hkl.shape[1]) + '.' , end = '\r')
+        
+        # compute crystal direction from peak data
+        c_dir = np.atleast_2d(np.dot(pd.latVecOps['B'] , hkl[:,jj])).T
+        
+        # compute distance from quaternions to crystallographic fiber
+        distance = rot.distanceToFiber(c_dir , s_dir , quats , pd.getQSym()) * r2d
+        
+        # filter for distances within specified distance bound
+        in_fiber = np.where(distance < distance_bnd)[0]
+        
+        # clever math trick for projecting strain 6-vector along strain direction of interest without converting to tensor form
+        project = np.array([s_dir[0]**2 , s_dir[1]**2 , s_dir[2]**2 , 2*s_dir[1]*s_dir[2] , 2*s_dir[0]*s_dir[2] , 2*s_dir[0]*s_dir[1]])        
+        
+        # calculate volume-weighted average of lattice strain for each fiber
+        # remove weights = vols[in_fiber] to get rid of volume-averaging
+        lattice_strains[ii,jj] = np.average(np.dot(project.T , strain[in_fiber , :].T) , weights = vols[in_fiber])
+        
+        del c_dir , distance , project , in_fiber
+    print('Lattice strains calculated.')
+        
+    del vols , quats , strain
+    
+print(fg.li_blue + '\nSaving lattice strains.' + fg.rs)
+np.savetxt(out_dir + 'lattice_strains.txt' , lattice_strains)
+print('Lattice strains saved.')
+
+#%% Plot lattice strain vs. cycle if enabled, and save figure if enabled.
+ 
+if plot :
+    
+    fig , ax = plt.subplots(1 , 1 , figsize = (4 , 4))
+    
+    for kk in range(hkl.shape[1]) :
+        ax.plot(lattice_strains[:,kk] , label = '%s' %hkl[:,kk])
+    
+    ax.set_xlabel('step')
+    ax.set_ylabel(r'lattice strain, $\epsilon_{hkl}$')
+    ax.legend()
+    
+    if save_plot :
+        
+        plt.savefig(out_dir + 'fig_lattice_strain_vs_step.png')
+
+    plt.show()

--- a/scripts/postprocessing/strain_Xtal_to_Sample.py
+++ b/scripts/postprocessing/strain_Xtal_to_Sample.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+@author: rjk5987, dcp5303
+
+This script converts the strain tensors for each element in an ExaConstit simulation
+at each time step from the crystal frame to the sample frame.
+These can be used, for example, to calculate lattice strains.
+
+Designed to take in outputs from adios2_extraction.py
+Requires that 'LatticeOrientation' and 'XtalElasticStrain' were output.
+
+Saves converted strains in ASCII text format (.txt) for use in other scripts.
+Output files named 'SampleElasticStrain' and labeled by cycle.
+
+Recommended to configure script in an interactive shell, then run from the command line.
+
+User inputs marked with #!!!
+"""
+
+import numpy as np
+import os
+
+from hexrd import rotations as rot
+
+# makes console print-outs nicer, can CTRL+F and remove these to eliminate this dependency
+from sty import bg , ef , fg
+
+#%% Specify filepaths. (USER INPUTS HERE)
+
+# directory where 'raw_' files were saved off from adios2_extraction.py
+in_dir = 'dir/to/adios2_extraction_files/' #!!!
+# save directory for script outputs, recursively create directory if it doesn't exist
+out_dir = 'dir/to/store/outputs/' #!!!
+if not os.path.exists(out_dir) :
+    print(fg.magenta + 'Output directory not found, creating.' + fg.rs)
+    os.makedirs(out_dir)
+else :
+    print(fg.green + 'Output directory found, proceeding.' + fg.rs)
+    
+#%% Convert from crystal frame to sample frame. (NO INPUTS HERE)
+
+# count number of simulation steps saved off
+steps = 0
+for fname in os.listdir(in_dir) :
+    if fname.startswith('raw_LatticeOrientation') :
+        steps += 1
+        
+print(ef.bold + bg.green + '\nConverting strains to sample frame.' + bg.rs + ef.rs)
+    
+for ii in range(steps) :
+    
+    print(ef.bold + bg.da_blue + '\nProcessing step ' + str(ii+1) + ' of ' + str(steps) + '.' + bg.rs + ef.rs)
+    
+    print(fg.li_blue + '\nLoading Xtal-to-ExaConstit lattice orientations.' + fg.rs)
+    quats_c_to_s = np.loadtxt(in_dir + 'raw_LatticeOrientation_%0.02d.txt' %ii).T           
+    print('Xtal-to-ExaConstit lattice orientations loaded.')
+    
+    # crystal-to-sample rotation matrices from quaternions
+    rmats_c_to_s = rot.rotMatOfQuat(np.atleast_2d(quats_c_to_s))
+    del quats_c_to_s
+
+    print(fg.li_blue + '\nLoading elastic strain in Xtal frame.' + fg.rs)
+    # strain 6-vector in crystal frame
+    strainV_c = np.loadtxt(in_dir + 'raw_XtalElasticStrain_%0.02d.txt' %ii)
+    print('Elastic strain in Xtal frame loaded.')
+    strainV_s = np.empty_like(strainV_c)
+    
+    for jj in range(strainV_c.shape[0]) :
+        print('Processing element ' + str(jj+1) + ' of ' + str(strainV_c.shape[0]) + '.' , end = '\r')
+        
+        # strain tensor in crystal frame (does not need factors of 2)
+        strainT_c = np.array([
+            [strainV_c[jj,0] , strainV_c[jj,5] , strainV_c[jj,4]] ,
+            [strainV_c[jj,5] , strainV_c[jj,1] , strainV_c[jj,3]] ,
+            [strainV_c[jj,4] , strainV_c[jj,3] , strainV_c[jj,2]]
+            ])   
+        
+        # strain tensor in HEXRD frame
+        strainT_s = np.dot(rmats_c_to_s[jj] , np.dot(strainT_c , rmats_c_to_s[jj].T))
+        # strain 6-vector in HEXRD frame
+        strainV_s[jj] = np.array([strainT_s[0,0] , strainT_s[1,1] , strainT_s[2,2] , strainT_s[1,2] , strainT_s[0,2] , strainT_s[0,1]])
+     
+    print(fg.li_blue + '\n\nSaving elastic strain in HEXRD frame.' + fg.rs)
+    np.savetxt(out_dir + 'SampleElasticStrain_%0.02d.txt' %ii , strainV_s)
+    print('Elastic strain in HEXRD frame saved.')
+    del strainV_c , strainV_s , strainT_c , strainT_s , rmats_c_to_s


### PR DESCRIPTION
Hi @rcarson3 ,

Here are the three scripts for the lattice strain calculation workflow (hopefully I'm doing this pull request correctly). 

1. adios2_extraction.py is an approach to pulling out a list of variables from ADIOS2 outputs made with large meshes in mind, so not the fastest but very careful in its use of memory. Supports many different variables and saves them in ASCII format by variable and cycle.
2. strain_Xtal_to_Sample.py converts the elastic strain tensors for each element from the crystal frame to the sample frame.
3. calc_lattice_strain.py calculates lattice strains as volume-averages of projected strain tensors over elements in crystallographic fibers.